### PR TITLE
Fixes bug where the EventManager cannot handle anonymous EventListeners.

### DIFF
--- a/src/main/java/me/itsghost/jdiscord/event/EventManager.java
+++ b/src/main/java/me/itsghost/jdiscord/event/EventManager.java
@@ -18,7 +18,8 @@ public class EventManager {
                 try {
                     if (m.getParameterTypes()[0].getName().equals(e.getClass().getName())) {
                         try {
-                            ClassO.getClass().getDeclaredMethod(m.getName(), e.getClass()).invoke(ClassO, e);
+                            m.setAccessible(true);
+                            m.invoke(ClassO, e);
                         } catch (Exception e1) {
                             e1.printStackTrace();
                             System.out.println("Couldn't run event!");


### PR DESCRIPTION
Without this fix you cannot use anonymous classes with the EventManager.
```Java
manager.registerListener(new EventListener()
        {
            public void onApiLoadedPublic(APILoadedEvent e)
            {
                System.out.println("Of course this was called!");
            }
});
```
Will not work.
If you are concerned about the change in accessibility due to the .setAccessible(true), I wrote a simple test bot that shows that Package, Protected and Private are NOT called, only Public methods are fired.  This is intended functionality and remains in-line with the previous functionality before the fix.
[jDiscord PR TestBot](http://pastebin.com/dx829hA7 "It is good eats, I swear")
